### PR TITLE
fix(codejar-linenumbers): remove the extra line number at the bottom

### DIFF
--- a/src/codejar-linenumbers.ts
+++ b/src/codejar-linenumbers.ts
@@ -32,7 +32,7 @@ export function withLineNumbers(
         }
 
         const code = editor.textContent || ""
-        const linesCount = code.replace(/\n\n$/g, "\n").split("\n").length
+        const linesCount = code.replace(/\n$/g, "").split("\n").length
 
         let text = ""
         for (let i = 0; i < linesCount; i++) {


### PR DESCRIPTION
Hello, when I tried using this library I ran into an issue, in that there was an extra number being shown at the bottom, even though there was visually no newline.

![image](https://github.com/julianpoemp/codejar-linenumbers/assets/49210777/b928b26a-8443-4328-a4ee-080e290a8a19)

This change should fix that to behave more predictably.